### PR TITLE
Updated logic for which models to include

### DIFF
--- a/preprocess_data/preprocess_forecasts.R
+++ b/preprocess_data/preprocess_forecasts.R
@@ -47,10 +47,10 @@ locations <- covidData::fips_codes %>%
     dplyr::pull(location)
 
 # models in viz
-models <- covidHubUtils::get_model_designations(
+models <- covidHubUtils::get_model_metadata(
     source = "local_hub_repo",
     hub_repo_path = hub_repo_path) %>%
-    dplyr::filter(designation %in% c("primary", "secondary")) %>%
+    dplyr::filter(designation %in% c("primary", "secondary") | ensemble_of_hub_models==TRUE) %>%
     dplyr::pull(model)
 
 for (target_var in c("case", "death", "hosp")) {


### PR DESCRIPTION
This change 
 - updates to use get_model_metadata() which won't be deprecated soon
 - adds logic so that models that are ensembles-of-hub-models will be included in the viz.